### PR TITLE
Bugfix: return checkDigit under 10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const getCheckDigit = (code: string): string => {
 
   const total = even * 3 + odd;
 
-  return (10 - getLastDigit(total)).toString(10);
+  return ((10 - getLastDigit(total)) % 10).toString(10);
 };
 
 /**


### PR DESCRIPTION
I found checkDigit bug.

```ts
getCheckDigit("490210526779")
// expect return "0"
// but actual "10"
```